### PR TITLE
Fix: 멤버 연관관계 삭제

### DIFF
--- a/src/main/kotlin/org/real7/luckywiki/domain/comment/dto/CommentResponse.kt
+++ b/src/main/kotlin/org/real7/luckywiki/domain/comment/dto/CommentResponse.kt
@@ -6,7 +6,7 @@ data class CommentResponse (
 //    val id: Long,
     val content:String,
     val vote : Boolean,
-//    val member:
+    val member: Long,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime
 ) {

--- a/src/main/kotlin/org/real7/luckywiki/domain/comment/dto/CommentResponse.kt
+++ b/src/main/kotlin/org/real7/luckywiki/domain/comment/dto/CommentResponse.kt
@@ -3,7 +3,7 @@ package org.real7.luckywiki.domain.comment.dto
 import java.time.LocalDateTime
 
 data class CommentResponse (
-//    val id: Long,
+    val id: Long,
     val content:String,
     val vote : Boolean,
     val member: Long,

--- a/src/main/kotlin/org/real7/luckywiki/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/org/real7/luckywiki/domain/comment/model/Comment.kt
@@ -39,13 +39,13 @@ class Comment private constructor(
     companion object {
         fun from(
             request: CommentRequest,
-            member: Member,
+            memberId: Long,
             debate : Debate
         ): Comment {
             return Comment(
                 content = request.content,
                 vote = request.vote,
-                memberId = member.id!!,
+                memberId = memberId,
                 debate = debate
             )
         }
@@ -63,5 +63,5 @@ fun Comment.toSimpleResponse() : SimpleCommentResponse{
 }
 
 fun Comment.toResponse(): CommentResponse {
-    return CommentResponse(content, vote, memberId, createdAt, updatedAt)
+    return CommentResponse(id!!, content, vote, memberId, createdAt, updatedAt)
 }

--- a/src/main/kotlin/org/real7/luckywiki/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/org/real7/luckywiki/domain/comment/model/Comment.kt
@@ -15,9 +15,7 @@ class Comment private constructor(
     content : String,
     vote : Boolean,
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    val member: Member,
+    memberId : Long,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "debate_id")
@@ -34,6 +32,9 @@ class Comment private constructor(
     var vote: Boolean = vote
     protected set
 
+    var memberId : Long = memberId
+        protected set
+
 
     companion object {
         fun from(
@@ -44,7 +45,7 @@ class Comment private constructor(
             return Comment(
                 content = request.content,
                 vote = request.vote,
-                member = member,
+                memberId = member.id!!,
                 debate = debate
             )
         }
@@ -62,5 +63,5 @@ fun Comment.toSimpleResponse() : SimpleCommentResponse{
 }
 
 fun Comment.toResponse(): CommentResponse {
-    return CommentResponse(content, vote, createdAt, updatedAt)
+    return CommentResponse(content, vote, memberId, createdAt, updatedAt)
 }

--- a/src/main/kotlin/org/real7/luckywiki/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/org/real7/luckywiki/domain/comment/service/CommentService.kt
@@ -22,10 +22,10 @@ class CommentService (
 
     @Transactional
     fun createComment(memberId:Long, debateId:Long, request: CommentRequest): SimpleCommentResponse {
-        val member = memberRepository.findByIdOrNull(memberId) ?: throw ModelNotFoundException("Member", memberId)
+        if(!memberRepository.existsById(memberId)) throw ModelNotFoundException("Member", memberId)
         val debate = debateRepository.findByIdOrNull(debateId) ?: throw ModelNotFoundException("Debate", debateId)
         val comment = commentRepository.save(
-            Comment.from(request, member, debate )
+            Comment.from(request, memberId, debate )
         )
 
         return comment.toSimpleResponse()
@@ -33,7 +33,7 @@ class CommentService (
     @Transactional
     fun updateComment(memberId:Long, commentId:Long, request: CommentRequest): SimpleCommentResponse {
         val comment = commentRepository.findByIdOrNull(commentId) ?: throw ModelNotFoundException("comment",commentId)
-        if(memberId != comment.member.id) throw AccessDeniedException("This feed/comment is not yours!!")
+        if(memberId != comment.memberId) throw AccessDeniedException("This feed/comment is not yours!!")
         comment.updateComment(request)
         return comment.toSimpleResponse()
     }
@@ -41,7 +41,7 @@ class CommentService (
     @Transactional
     fun deleteComment(memberId:Long, commentId:Long) {
         val comment = commentRepository.findByIdOrNull(commentId) ?: throw ModelNotFoundException("comment", commentId)
-        if(memberId != comment.member.id) throw AccessDeniedException("This feed/comment is not yours!!")
+        if(memberId != comment.memberId) throw AccessDeniedException("This feed/comment is not yours!!")
         commentRepository.delete(comment)
 
     }


### PR DESCRIPTION
저장할때는 멤버 객체 만든다음에 저장하는게 없는 멤버로 저장할 가능성 배제할수있을것같아서 그런방향으로 수정했습니다.